### PR TITLE
bugfix server.config.proxies in apexofficeprint/printjob.py

### DIFF
--- a/apexofficeprint/config/server.py
+++ b/apexofficeprint/config/server.py
@@ -157,7 +157,6 @@ class Server:
         """
         Args:
             url (str): `Server.url`.
-            proxies (Dict[str, str]): `Server.proxies`
             config (ServerConfig): `Server.config`
         """
         self.url = url

--- a/apexofficeprint/printjob.py
+++ b/apexofficeprint/printjob.py
@@ -58,7 +58,7 @@ class PrintJob:
     def execute(self) -> Response:
         """Execute this print job."""
         self.server._raise_if_unreachable()
-        return self._handle_response(requests.post(self.server.url, proxies=self.server.proxies, json=self.as_dict))
+        return self._handle_response(requests.post(self.server.url, proxies=self.server.config.proxies, json=self.as_dict))
 
     async def execute_async(self) -> Response:
         """Async version of `PrintJob.execute`"""
@@ -67,7 +67,7 @@ class PrintJob:
                 None, partial(
                     requests.post,
                     self.server.url,
-                    proxies=self.server.proxies,
+                    proxies=self.server.config.proxies,
                     json=self.as_dict
                 )
             )
@@ -76,7 +76,7 @@ class PrintJob:
     @staticmethod
     def execute_full_json(json_data: str, server: Server) -> Response:
         server._raise_if_unreachable()
-        return PrintJob._handle_response(requests.post(server.url, proxies=server.proxies, data=json_data, headers={"Content-type": "application/json"}))
+        return PrintJob._handle_response(requests.post(server.url, proxies=server.config.proxies, data=json_data, headers={"Content-type": "application/json"}))
 
     @staticmethod
     async def execute_full_json_async(json_data: str, server: Server) -> Response:
@@ -86,7 +86,7 @@ class PrintJob:
                 None, partial(
                     requests.post,
                     server.url,
-                    proxies=server.proxies,
+                    proxies=server.config.proxies,
                     data=json_data,
                     headers={"Content-type": "application/json"}
                 )

--- a/test.py
+++ b/test.py
@@ -1,5 +1,4 @@
 import apexofficeprint as aop
-from copy import deepcopy
 import asyncio
 
 TEMPLATE_PATH = "./test/template.docx"
@@ -105,16 +104,19 @@ async def test_async():
 
 
 def test_full_json():
+    server = aop.config.Server(
+        LOCAL_SERVER_URL,
+        aop.config.ServerConfig(api_key=API_KEY)
+    )
     json_file = open("./test/full_test.json", "r")
     json_data = json_file.read()
-    aop.PrintJob.execute_full_json(json_data, aop.config.Server(
-        LOCAL_SERVER_URL)).to_file("./test/from_full_json_output")
+    aop.PrintJob.execute_full_json(json_data, server).to_file("./test/from_full_json_output")
 
 
 if __name__ == "__main__":
     # test1()
     # test_full_json()
     # asyncio.run(test_async())
-    # chartTest()
+    # test_chart()
     # test_aopchart()
     pass


### PR DESCRIPTION
Change server.proxies to server.config.proxies in apexofficeprint/printjob.py, because server doesn't have a 'proxies' argument. The 'proxies' argument is from server.config.
Found this bug because of an error: "AttributeError: 'Server' object has no attribute 'proxies'" when trying to get the output file for a full json input. After the bugfix, I successfully get the output file for a full json input file.